### PR TITLE
Fixes swiping

### DIFF
--- a/prototype/src/App.elm
+++ b/prototype/src/App.elm
@@ -81,9 +81,9 @@ app = StartApp.start
     { init = (initialApp, Effects.none)
     , view = view
     , update = update
-    , inputs = [history.signal, userLocation]
+    --, inputs = [history.signal, userLocation]
+    , inputs = [history.signal, Swiping.animate, userLocation]
     }
-    --, inputs = [history.signal, Swiping.animate, userLocation]
 
 {-| The HTML view created by the app -}
 main : Signal Html

--- a/prototype/src/App.elm
+++ b/prototype/src/App.elm
@@ -178,7 +178,12 @@ and viewing the console while starting the app.
 
 -}
 update: AppAction -> AppModel -> (AppModel, Effects.Effects AppAction)
-update action model = (updateModel (Debug.log "updateModel action:" action) (Debug.log "updateModel model:" model), updateAction (Debug.log "updateAction action:" action) (Debug.log "updateAction model:" model))
+update action model =
+    let
+        _ = Debug.log "update w/ model.location" model.location
+        _ = Debug.log "update w/ action" action
+    in
+        (updateModel action model, updateAction action model)
 
 
 {-| This function updates the state of the app based on the given action and previous state of the app
@@ -210,7 +215,12 @@ updateModel action app = case (app.location, action) of
     -- Geoposition update actions
     (_, UpdateLocation loc)                   -> {app | latLng = Debug.log "model setting GPS coords: " loc }
     -- Do nothing for the rest of the actions
-    (_, _)                                    -> (Debug.log "uM: (_,_)" app)
+    (_, _)                                    ->
+        let
+            _ = Debug.log "updateModel, no change for location" app.location
+            _ = Debug.log "updateModel, no change for action  " action
+        in
+            app
 
 
 

--- a/prototype/swipe-local-history.js
+++ b/prototype/swipe-local-history.js
@@ -15223,18 +15223,20 @@ Elm.Main.make = function (_elm) {
             case "UpdateLocation": return _U.update(app,{latLng: A2($Debug.log,"model setting GPS coords: ",_p18._1._0)});
             default: break _v10_15;}
       } while (false);
-      return A2($Debug.log,"uM: (_,_)",app);
+      var _p22 = A2($Debug.log,"updateModel, no change for action  ",action);
+      var _p23 = A2($Debug.log,"updateModel, no change for location",app.location);
+      return app;
    });
    var update = F2(function (action,model) {
-      return {ctor: "_Tuple2"
-             ,_0: A2(updateModel,A2($Debug.log,"updateModel action:",action),A2($Debug.log,"updateModel model:",model))
-             ,_1: A2(updateAction,A2($Debug.log,"updateAction action:",action),A2($Debug.log,"updateAction model:",model))};
+      var _p24 = A2($Debug.log,"update w/ action",action);
+      var _p25 = A2($Debug.log,"update w/ model.location",model.location);
+      return {ctor: "_Tuple2",_0: A2(updateModel,action,model),_1: A2(updateAction,action,model)};
    });
    var initialApp = {location: $Types.Discovering,discovery: initialDiscovery,items: $Remote$DataStore.empty,latLng: $Maybe.Nothing};
    var app = $StartApp.start({init: {ctor: "_Tuple2",_0: initialApp,_1: $Effects.none}
                              ,view: $View.view
                              ,update: update
-                             ,inputs: _U.list([history.signal,userLocation])});
+                             ,inputs: _U.list([history.signal,$Swiping.animate,userLocation])});
    var main = app.html;
    var tasks = Elm.Native.Task.make(_elm).performSignal("tasks",app.tasks);
    var routeTasks = Elm.Native.Task.make(_elm).performSignal("routeTasks",


### PR DESCRIPTION
Re-enables swiping. Leads to more active debug output in console (partly to address this, there is a commit that cleans up debug logging a bit) but swiping works again.