### PR TITLE
better style for fav / pass overlays while swiping

### DIFF
--- a/prototype/style.css
+++ b/prototype/style.css
@@ -156,13 +156,18 @@ html, body, body > div {
 
                 .discovery-story-image i {
                     opacity: 0.5;
-                    font-size: 10em;
+                    font-size: 8em;
+                    position: absolute;
+                    top: 65px;
+                    margin: 0rem 1rem;
                 }
                 .discovery-story-image i.favourite {
                     color: #417505;
+                    right: 0;
                 }
                 .discovery-story-image i.pass {
                     color: red;
+                    left: 0;
                 }
 
             .discovery-story-details 


### PR DESCRIPTION
Fixes #102

* absolute position so presence doesn't affect layout of other page items
* position below menu (65px from top)
* move away from left/right edges (margin), while putting fav or pass overlay on
  appropriate side to match swipe direction and fav/pass buttons (right and left positioning)
* icon was a big large, made it smaller (8em vs 10em)