### PR TITLE
cleaner story page loading + a couple tweaks

### DIFF
--- a/prototype/src/Story.elm
+++ b/prototype/src/Story.elm
@@ -21,30 +21,40 @@ import Swiping exposing (onSwipe, swipePhotoAction, itemSwipe, itemPos)
 Displays a simpler view if only part of the story is available.
 -} 
 view : Signal.Address AppAction -> RemoteData Story -> ItemView -> StoryScreen -> Html
-view address story item storyScreen = div [class "story"]
-    <| case story of
-        Loaded story ->
-            [ photoSlider address story item storyScreen
-            , metaHtml story storyScreen
-            ] ++ case story of
-                DiscoverStory discoverStory -> [loading]
-                FullStory fullStory -> [
-                    buttons address story storyScreen
-                    , introOrBody story storyScreen
-                    , moreInfo address story storyScreen
-                    ]
-        Failed error ->
-            [ div [class "error"] [text "Something went wrong: ", text <| toString <| log error]]
-        Loading ->
-            [ loading ]
+view address story item storyScreen =
+    let
+        loadStatus =
+            case story of
+                Loaded (DiscoverStory s) -> "story-loading" -- because no FullStory yet
+                _ -> ""
+    in div [class <| "story content-area " ++ loadStatus]
+        <| case story of
+            Loaded story ->
+                [ photoSlider address story item storyScreen
+                , metaHtml story storyScreen
+                ] ++ case story of
+                    DiscoverStory discoverStory -> [loading]
+                    FullStory fullStory -> [
+                        buttons address story storyScreen
+                        , introOrBody story storyScreen
+                        , moreInfo address story storyScreen
+                        ]
+            Failed error ->
+                [ div [class "error"] [text "Something went wrong: ", text <| toString <| log error]]
+            Loading ->
+                [ loading ]
 
 
 metaHtml : Story -> StoryScreen -> Html
 metaHtml story screen =
     case (story, screen) of
 
-        (DiscoverStory _, _) ->
-            titleHtml story
+        (DiscoverStory s, _) ->
+
+            div [class "screen-header"] [
+                titleHtml story
+                , div [class "story-site"] [text (sitesName s.sites)]
+            ]
 
         (FullStory _, MoreInfo) ->
             text ""

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -37,6 +37,14 @@ html, body, body > div {
      z-index: 2;
 }
 
+/* adjust some screens to start after nav bar
+   (but not all: screens with photos start beneath nav bar) */
+.favourites-screen .favourites,
+.story-screen.story-body .fullStory-meta,
+.story-screen.story-more-info .content-area {
+    margin-top: 65px;
+}
+
 /*.story-screen .navigation, 
 .favourites-screen .navigation  {
     background: rgba(0, 0, 0, 0.6);
@@ -284,7 +292,6 @@ html, body, body > div {
 /* Favourites list style */
 .favourites {
     margin: 16px;
-    margin-top: 65px;
 }
 
     .favourites .favourites-empty {
@@ -386,7 +393,6 @@ html, body, body > div {
         .story {
             height: auto;
             min-height: 100vh;
-            /* margin-top: 65px; */ /* match height of navigation bar */
             background-color: #FCFCFC; /* just off white */
             color: #343434;
             padding-bottom: 10px;
@@ -535,9 +541,10 @@ html, body, body > div {
    .story-body .fullStory-meta {
          background: none;
          position: absolute;
-         top: 65px;
-         display: block;
-         margin: 0;
+         top: 0;
+         margin-left: 0;
+         margin-right: 0;
+         margin-bottom: 0;
          z-index: 1;
     }
     
@@ -600,7 +607,6 @@ html, body, body > div {
     background-color: #77a131;
 }
     .story-more-info .screen-header {
-        margin-top: 65px;
         padding-bottom: 2rem;
         padding-top: 1rem;
     }

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -738,6 +738,7 @@ p {
     /* color:#343434; */
     line-height: 1.4;
     padding-left: 16px;
+    padding-right: 16px;
     font-weight: normal;
 }
 

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -389,6 +389,23 @@ html, body, body > div {
                 background-image: url("/images/button-directions-active.png");
             }
 
+/* Story loading style */
+.story-loading .screen-header {
+    position: absolute;
+    top: 265px; /* height of photos that load here */
+}
+    .story-loading .loading {
+        margin: 0;
+        position: absolute;
+        top: 0;
+        width: 100%;
+        height: 265px;
+    }
+    .story-loading .loading i.fa {
+        top: 50%;
+        position: relative;
+    }
+
 /* Story page style */
         .story {
             height: auto;
@@ -595,6 +612,9 @@ html, body, body > div {
     .story-body .links a {
         display: none;
     }
+
+
+
 
 
 .screen-header {


### PR DESCRIPTION
Addresses #104 

* adds 'loading' class
* includes site name in preview before loading FullStory
* add CSS to prevent page jumping around during loading  …
* we also move where the loading spinner sits so it is in middle of where images will go

Tweaks:
* paragraph margin so paragraphs don't butt up against right side
* less magic #s related to 65px tall fixed nav bar and content below or beneath it