### PR TITLE
Position story title relative to story content screen

### DIFF
--- a/prototype/style.css
+++ b/prototype/style.css
@@ -508,6 +508,9 @@ html, body, body > div {
     }
 
 /* Story page style */
+        .story.content-area {
+            position: relative; /* so we can absolutely position .fullStory-meta relative to this */
+        }
         .story {
             height: auto;
             min-height: 100vh;


### PR DESCRIPTION
Fixes #111 where story title wasn't scrolling, covered body text as that slid underneath