### PR TITLE
add map

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -12,8 +12,8 @@
         <link rel="stylesheet" type="text/css" href="style.css">
         <link rel="stylesheet" type="text/css" href="css/loaders.min.css">
         <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
-        <link rel="stylesheet" href="https://npmcdn.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
-        <script src="https://npmcdn.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script>
+        <script src='https://api.mapbox.com/mapbox-gl-js/v0.22.0/mapbox-gl.js'></script>
+        <link href='https://api.mapbox.com/mapbox-gl-js/v0.22.0/mapbox-gl.css' rel='stylesheet' />
 
         <script src="https://use.typekit.net/tzz4als.js"></script>
         <script>try{Typekit.load({ async: true });}catch(e){}</script>
@@ -65,35 +65,184 @@
                 app.ports.geolocation.send(null);
             }
 
-            /* show map when Elm wants us to */
-            mapEl = document.getElementById("map");
-            app.ports.showMap.subscribe(function(showMap) {
-                console.log("show map: " + showMap);
-                if (showMap) {
-                    mapEl.style.zIndex = '2';
 
-                } else {
-                    mapEl.style.zIndex = '-1';
-                }
-            });
-
-
+            var map = null;
             function setupMap() {
 
-                var map = L.map('map').setView([-33.868820, 151.209296], 13);
+                // TODO: when user location changes, update person marker
+                var startLngLat = [151.209296, -33.868820];  // just Sydney for now: TODO - USER LOCATION
 
-                L.tileLayer('https://api.tiles.mapbox.com/v4/mapbox.emerald/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoidGVjaGllc2hhcmsiLCJhIjoiYzk2ZEFWTSJ9.8ZY6rG2BWXkDBmvAPvn_nw', {
-                    attribution: 'Mapbox <a href="https://mapbox.com/about/maps" target="_blank">Terms &amp; Feedback</a>'
-                }).addTo(map);
+                mapboxgl.accessToken = 'pk.eyJ1IjoiamVzc2Vtb3JlYnVycml0b3MiLCJhIjoiY2lraHBxMm10MDI4b3RubTZ1ZnU0emF0eSJ9.1XYxvJb60uABEGx4aDXTbg';
 
-                // Latitude: N (+90), S (-90)
-                // Longitude: E (+180) / W (-180)
-                L.marker([-33.9, 151.209296]).addTo(map)
-                    .bindPopup('A pretty CSS3 popup.<br> Easily customizable.')
-                    .openPopup();
+                map = new mapboxgl.Map({
+                    container: 'map',
+                    style: 'mapbox://styles/jessemoreburritos/cikhuc8i600239vm0q8524u9e',
+                    center: startLngLat,
+                    zoom: 13,
+                });
+
+                function mapClickHandler (e) {
+                    var features = map.queryRenderedFeatures(e.point, { layers: ['places'] });
+
+                    if (!features.length) {
+                        return;
+                    }
+
+                    var feature = features[0];
+
+                    // Populate the popup and set its coordinates
+                    // based on the feature found.
+                    var popup = new mapboxgl.Popup()
+                        .setLngLat(feature.geometry.coordinates)
+                        .setHTML(feature.properties.description)
+                        .addTo(map);
+                }
+
+                // When a click event occurs near a place, open a popup at the location of
+                // the feature, with description HTML from its properties.
+                map.on('click', mapClickHandler);
             }
 
             setupMap();
+
+
+            // rowToFeature : row -> GeoJSON Feature
+            function rowToFeature (row) {
+                return {
+                    "type": "Feature",
+                    "properties": row,
+                    "geometry":
+                        {
+                            "type": "Point",
+                            "coordinates": [row.longitude, row.latitude]
+                        }
+                }
+            }
+
+            //toGeoJson : List row -> GeoJSON object
+            function toGeoJson (rows) {
+                return {
+                        "type": "FeatureCollection",
+                        "features": rows.map(rowToFeature)
+                    }
+            }
+
+            var geojson;
+            var popups = [];
+
+            function closeAllPopups () {
+                popups.forEach(function (popup) {
+                    popup.remove();
+                })
+            }
+
+            function popupContent (marker) {
+
+                function storyCountOrOnlyStoryTitle (marker) {
+                    var p = marker.properties,
+                        s = p.stories[0];
+
+                    return p.story_count !== 1 ?
+                        p.story_count :
+                        '<a href="#!/story/' + s.id + '">' + s.title + '</a>';
+                }
+
+                return '' +
+                    '<article class="popup">' +
+                        '<header class="popup-site-overview">' +
+                            '<div class="popup-site-text">' +
+                                '<h1>' + marker.properties.name + '</h1>' +
+                                storyCountOrOnlyStoryTitle(marker) +
+                            '</div>' +
+                            '<div class="popup-site-image">' +
+                                '<img src="' + marker.properties.featured_photo + '">' +
+                            '</div>'
+                        '</header>' +
+                    '</article>';
+            }
+
+            // request sites to put on map
+            function getSites () {
+                var request = new XMLHttpRequest();
+                request.open('GET', '/api/rpc/all_site', true);
+
+                request.onload = function() {
+                  if (request.status >= 200 && request.status < 400) {
+                    // Success!
+                    var data = JSON.parse(request.responseText);
+                    console.log("fetched sites:");
+                    console.log(data);
+                    geojson = toGeoJson(data);
+                    console.log("geojson:");
+                    console.log(geojson);
+
+                    map.once('load', function load() {
+                        console.log("map: adding source to mapbox");
+                        map.addSource('heritage-sites', {type: 'geojson', data: geojson});
+
+                        // add markers to map
+                        geojson.features.forEach(function(marker) {
+
+                            // create an image element for the marker
+                            var el = document.createElement('button');
+                            el.className = 'site-marker';
+                            el.style.backgroundImage = 'url(' + marker.properties.featured_photo + ')';
+
+                            el.addEventListener('click', function() {
+                                closeAllPopups();
+                                var popup = new mapboxgl.Popup({closeOnClick: false})
+                                    .setLngLat(marker.geometry.coordinates)
+                                    .setHTML(popupContent(marker))
+                                    .addTo(map);
+                                popups.push(popup);
+                            });
+
+                            // add marker to map
+                            new mapboxgl.Marker(el)
+                                .setLngLat(marker.geometry.coordinates)
+                                .addTo(map);
+
+                        });
+
+
+
+                    });
+
+                  } else {
+                    // We reached our target server, but it returned an error
+                    console.log("failed fetching sites from server")
+                  }
+                };
+
+                request.onerror = function() {
+                  // There was a connection error of some sort
+                  console.log("connection error while fetching sites");
+                };
+
+                request.send();
+            }
+
+            getSites();
+
+
+
+
+            /* show map when Elm wants us to */
+            mapContainerEl = document.getElementsByClassName("map-container")[0];
+            app.ports.showMap.subscribe(function(showMap) {
+                console.log("show map: " + showMap);
+                if (showMap) {
+                    mapContainerEl.style.zIndex = '1';
+                } else {
+                    mapContainerEl.style.zIndex = '-1';
+                }
+            });
+
+            // var markers = null;
+            // app.ports.mapMarkers.subscribe(function (data) {
+            //     console.log("map markers:");
+            //     console.log(data);
+            // });
 
 
             /* preload images - define and run immediately */

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -12,6 +12,9 @@
         <link rel="stylesheet" type="text/css" href="style.css">
         <link rel="stylesheet" type="text/css" href="css/loaders.min.css">
         <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+        <link rel="stylesheet" href="https://npmcdn.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
+        <script src="https://npmcdn.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script>
+
         <script src="https://use.typekit.net/tzz4als.js"></script>
         <script>try{Typekit.load({ async: true });}catch(e){}</script>
         <script type="text/javascript" src="swipe-local-history.js"></script>
@@ -19,6 +22,12 @@
     <body>
         <!-- preload font awesome -->
         <i style="color:transparent; opacity: 0.001; position: absolute;" class="fa fa-times"> </i>
+
+        <div id="elm"></div>
+        <div class="map-container">
+            <div id="map"></div>
+        </div>
+
 
         <script type="text/javascript">
             // Make :active work in mobile safari
@@ -33,7 +42,8 @@
             });
 
             // Start app
-            var app = Elm.fullscreen(Elm.Main, {
+            var node = document.getElementById("elm");
+            var app = Elm.embed(Elm.Main, node, {
                 geolocation: null,
             });
 
@@ -54,6 +64,37 @@
             function noLocation() {
                 app.ports.geolocation.send(null);
             }
+
+            /* show map when Elm wants us to */
+            mapEl = document.getElementById("map");
+            app.ports.showMap.subscribe(function(showMap) {
+                console.log("show map: " + showMap);
+                if (showMap) {
+                    mapEl.style.zIndex = '2';
+
+                } else {
+                    mapEl.style.zIndex = '-1';
+                }
+            });
+
+
+            function setupMap() {
+
+                var map = L.map('map').setView([-33.868820, 151.209296], 13);
+
+                L.tileLayer('https://api.tiles.mapbox.com/v4/mapbox.emerald/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoidGVjaGllc2hhcmsiLCJhIjoiYzk2ZEFWTSJ9.8ZY6rG2BWXkDBmvAPvn_nw', {
+                    attribution: 'Mapbox <a href="https://mapbox.com/about/maps" target="_blank">Terms &amp; Feedback</a>'
+                }).addTo(map);
+
+                // Latitude: N (+90), S (-90)
+                // Longitude: E (+180) / W (-180)
+                L.marker([-33.9, 151.209296]).addTo(map)
+                    .bindPopup('A pretty CSS3 popup.<br> Easily customizable.')
+                    .openPopup();
+            }
+
+            setupMap();
+
 
             /* preload images - define and run immediately */
             function preloadImages() {

--- a/prototype/src/App.elm
+++ b/prototype/src/App.elm
@@ -119,6 +119,9 @@ history = Signal.mailbox NoAction
 {-| Location from browser -}
 port geolocation : Signal Json.Encode.Value
 
+-- extra port
+port showMap : Signal Bool
+port showMap = Signal.map (\m -> m.location == MapScreen) app.model
 {-| Signal with Actions to update the user's location.
 If `Nothing` then the user has disallowed geolocation.
 -}

--- a/prototype/src/App.elm
+++ b/prototype/src/App.elm
@@ -214,6 +214,7 @@ updateModel action app = case (app.location, action) of
     (_, View story' screen')                  -> {app | location = Viewing story' initialItemView screen'}
     (_, ViewFavourites)                       -> {app | location = ViewingFavourites}
     (_, ViewAboutScreen)                      -> {app | location = AboutScreen}
+    (_, ViewMapScreen)                        -> {app | location = MapScreen}
     -- Data update actions
     (_, LoadData updateItems)                 -> {app | items = updateItems app.items}
     (_, LoadDiscoveryData items updateItems)  -> {app | items = updateItems app.items, discovery = updateDiscoverableItems app.discovery items}

--- a/prototype/src/App.elm
+++ b/prototype/src/App.elm
@@ -121,7 +121,12 @@ port geolocation : Signal Json.Encode.Value
 
 -- extra port
 port showMap : Signal Bool
-port showMap = Signal.map (\m -> m.location == MapScreen) app.model
+port showMap =
+    let
+        booleanSignal =  Signal.map (\m -> m.location == MapScreen) app.model
+    in
+        Signal.dropRepeats booleanSignal
+
 {-| Signal with Actions to update the user's location.
 If `Nothing` then the user has disallowed geolocation.
 -}

--- a/prototype/src/App.elm
+++ b/prototype/src/App.elm
@@ -37,6 +37,7 @@ import StartApp
 import Types exposing (..)
 import Remote.Data exposing (RemoteData(..))
 import Remote.DataStore exposing (RemoteDataStore)
+import Encoders exposing (remoteFullStoriesMapEncoder)
 import Route
 import Data
 import View exposing (view)
@@ -126,6 +127,13 @@ port showMap =
         booleanSignal =  Signal.map (\m -> m.location == MapScreen) app.model
     in
         Signal.dropRepeats booleanSignal
+
+
+{-| Any time the model changes, Json-encode our fetched stories and send to JavaScript-land for mapping. -}
+--port mapMarkers : Signal Json.Encode.Value
+--port mapMarkers =
+--    Signal.map (\m -> remoteFullStoriesMapEncoder m.items) app.model
+
 
 {-| Signal with Actions to update the user's location.
 If `Nothing` then the user has disallowed geolocation.

--- a/prototype/src/Encoders.elm
+++ b/prototype/src/Encoders.elm
@@ -1,0 +1,141 @@
+module Encoders (remoteFullStoriesMapEncoder) where
+
+{-| JSON encoders.
+
+Might be useful for sending Elm records to JavaScript land through ports, for example.
+-}
+
+import Json.Encode
+
+import Types exposing (..)
+import Story
+import Remote.DataStore exposing (RemoteDataStore)
+
+
+
+{-| encode the parts of the story we need to pass through to JS map -}
+remoteFullStoriesMapEncoder : RemoteDataStore StoryId Story -> Json.Encode.Value
+remoteFullStoriesMapEncoder items =
+    let
+        stories = Remote.DataStore.loaded items
+        fullStories = takeFullStories stories
+    in
+        fullStoriesMapEncoder fullStories
+
+
+--remoteStoriesMapEncoder : RemoteDataStore StoryId Story -> Json.Encode.Value
+--remoteStoriesMapEncoder items =
+--    let
+--        stories = Remote.DataStore.loaded items
+--        --fullStories = takeFullStories stories
+--    in
+--        allStoriesMapEncoder stories
+
+
+fullStoriesMapEncoder : List Story -> Json.Encode.Value
+fullStoriesMapEncoder stories =
+    let
+        listOfValues = List.map fullStoryMapEncoder stories
+    in
+        Json.Encode.list listOfValues
+
+
+--allStoriesMapEncoder : List Story -> Json.Encode.Value
+--allStoriesMapEncoder stories =
+--    let
+--        listOfValues = List.map storyMapEncoder stories
+--    in
+--        Json.Encode.list listOfValues
+
+
+{-| Encodes just some fields [1] from just some stories [2].
+1: We just want fields like lat/long a site name, and
+photo url, to provide story summary in popup marker.
+
+2: We only want to output full stories, since those have lat/long that we need.
+-}
+fullStoryMapEncoder : Story -> Json.Encode.Value
+fullStoryMapEncoder story =
+    case story of
+
+        DiscoverStory s ->
+            Json.Encode.object
+                [ ("error", Json.Encode.string "was not expecting discover story") ]
+
+        FullStory s ->
+            Json.Encode.object
+                [ ("storyId", Json.Encode.string <| Story.storyIdToStr s.id)
+                , ("photoUrl", stringOrNullEncoder <| List.head s.photos)
+                , ("distance", floatOrNullEncoder s.distance)
+                , ("firstLocation", latLngOrNullEncoder <| List.head s.locations)
+                , ("firstSiteName", Json.Encode.string <| siteNameOrDefault <| List.head s.sites)
+                ]
+
+
+{-| Encodes just some fields [1].
+1: We just want fields like lat/long a site name, and
+photo url, to provide story summary in popup marker.
+-}
+--storyMapEncoder : Story -> Json.Encode.Value
+--storyMapEncoder story =
+--    case story of
+
+--        DiscoverStory s ->
+--            Json.Encode.object
+--                [ ("storyId", Json.Encode.string <| Story.storyIdToStr s.id)
+--                , ("photoUrl", Json.Encode.string s.photo)
+--                , ("distance", floatOrNullEncoder s.distance)
+--                , ("firstLocation", latLngOrNullEncoder <| List.head s.locations)
+--                , ("firstSiteName", Json.Encode.string <| siteNameOrDefault <| List.head s.sites)
+--                ]
+
+--        FullStory s ->
+--            Json.Encode.object
+--                [ ("storyId", Json.Encode.string <| Story.storyIdToStr s.id)
+--                , ("photoUrl", stringOrNullEncoder <| List.head s.photos)
+--                , ("distance", floatOrNullEncoder s.distance)
+--                , ("firstLocation", latLngOrNullEncoder <| List.head s.locations)
+--                , ("firstSiteName", Json.Encode.string <| siteNameOrDefault <| List.head s.sites)
+--                ]
+
+
+siteNameOrDefault : Maybe Site -> String
+siteNameOrDefault site =
+    case site of
+        Just site -> site.name
+        Nothing -> "No known sites"
+
+
+latLngEncoder : LatLng -> Json.Encode.Value
+latLngEncoder latlng =
+    Json.Encode.object
+        [ ("lat", Json.Encode.string latlng.lat)
+        , ("lng", Json.Encode.string latlng.lng)
+        ]
+
+latLngOrNullEncoder : Maybe LatLng -> Json.Encode.Value
+latLngOrNullEncoder val = maybeEncoder val latLngEncoder
+
+stringOrNullEncoder : Maybe String -> Json.Encode.Value
+stringOrNullEncoder val = maybeEncoder val Json.Encode.string
+
+floatOrNullEncoder : Maybe Float -> Json.Encode.Value
+floatOrNullEncoder val = maybeEncoder val Json.Encode.float
+
+maybeEncoder : Maybe a -> (a -> Json.Encode.Value) -> Json.Encode.Value
+maybeEncoder val encoder =
+    case val of
+        Just val -> encoder val
+        Nothing -> Json.Encode.null
+
+
+takeFullStories : List Story -> List Story
+takeFullStories list = List.filter isFullStory list
+
+isFullStory : Story -> Bool
+isFullStory story =
+    case story of
+        FullStory s -> True
+        _ -> False
+
+

--- a/prototype/src/Navigation.elm
+++ b/prototype/src/Navigation.elm
@@ -1,6 +1,6 @@
 module Navigation (navigation) where
 
-import Html exposing (Html, div, nav, h1, img, button, a, i, text)
+import Html exposing (Html, div, span, nav, h1, img, button, a, i, text)
 import Html.Attributes exposing (class, src, href)
 import Html.Events exposing (onClick)
 
@@ -9,57 +9,55 @@ import Types exposing (..)
 {-| The top level navigation view for the app -}
 navigation : Signal.Address AppAction -> AppLocation -> Html
 navigation address location =
-    nav [class "navigation"] [ buttonHtml address location, titleHtml location]
-
-
-
-{-| Generate the title of the nav bar, which may vary depending on the screen -}
-titleHtml : AppLocation -> Html
-titleHtml location =
     let
-        container = div [class "navigation-center"]
+        -- define some html components
+        goBackButton = button [onClick address Back] [i [class "fa fa-angle-left fa-3x"] []]
+        goDiscoverButton = button [onClick address Discover] [i [class "fa fa-map fa-2x"] []]
+        goFavsButton = button [onClick address ViewFavourites] [i [class "fa fa-heart fa-2x"] []]
+        logoDiv = div [class "logo"] [a [href "/"] [img [src "images/logo.png"] []]]
+        navTitle title = h1 [] [text title]
+        noNavBar = text ""
     in
+        -- produce a different nav bar for every AppLocation
         case location of
 
-            SplashPage -> none
+            SplashPage -> noNavBar
 
-            AboutScreen ->
-                container [h1 [] [text "About"]]
+            AboutScreen -> navBarHtml
+                { side1 = [goBackButton]
+                , center = [navTitle "About"]
+                , side2 = []
+                }
 
-            Discovering ->
-                container [logoDiv]
+            Viewing _ _ _ -> navBarHtml
+                { side1 = [goBackButton]
+                , center = [logoDiv]
+                , side2 = []
+                }
 
-            Viewing _ _ _ ->
-                container [logoDiv]
+            ViewingFavourites -> navBarHtml
+                { side1 = [goDiscoverButton]
+                , center = [navTitle "Favourites"]
+                , side2 = []
+                }
 
-            ViewingFavourites ->
-                container [h1 [] [text "Favourites"]]
+            Discovering -> navBarHtml
+                { side1 = [goFavsButton]
+                , center = [logoDiv]
+                , side2 = []
+                }
 
-logoDiv = div [class "logo"] [a [href "/"] [img [src "images/logo.png"] []]]
 
+type alias NavBarElements =
+    { side1 : List Html
+    , center : List Html
+    , side2 : List Html
+    }
 
-{-| Generate the top button on the nav bar, which may vary depending on the screen. -}
-buttonHtml : Signal.Address AppAction -> AppLocation -> Html
-buttonHtml address location =
-    case location of
-
-        SplashPage -> none
-
-        AboutScreen ->
-            backButton address
-
-        Discovering ->
-            button [onClick address ViewFavourites] [i [class "fa fa-heart fa-2x"] []]
-
-        Viewing _ _ _ ->
-            backButton address
-
-        ViewingFavourites ->
-             button [onClick address Discover] [i [class "fa fa-map fa-2x"] []]
-
-backButton : Signal.Address AppAction -> Html
-backButton address =
-    button [onClick address Back] [i [class "fa fa-angle-left fa-3x"] []]
-
-none : Html
-none = text ""
+navBarHtml : NavBarElements -> Html
+navBarHtml bar =
+    nav [class "navigation"]
+        [ div [class "navigation-side1"] bar.side1
+        , div [class "navigation-center"] bar.center
+        , div [class "navigation-side2"] bar.side2
+        ]

--- a/prototype/src/Navigation.elm
+++ b/prototype/src/Navigation.elm
@@ -36,15 +36,15 @@ navigation address location =
                 }
 
             ViewingFavourites -> navBarHtml
-                { side1 = [goDiscoverButton]
+                { side1 = [goBackButton]
                 , center = [navTitle "Favourites"]
                 , side2 = []
                 }
 
             Discovering -> navBarHtml
-                { side1 = [goFavsButton]
+                { side1 = []
                 , center = [logoDiv]
-                , side2 = []
+                , side2 = [goFavsButton]
                 }
 
 

--- a/prototype/src/Navigation.elm
+++ b/prototype/src/Navigation.elm
@@ -12,7 +12,8 @@ navigation address location =
     let
         -- define some html components
         goBackButton = button [onClick address Back] [i [class "fa fa-angle-left fa-3x"] []]
-        goDiscoverButton = button [onClick address Discover] [i [class "fa fa-map fa-2x"] []]
+        goDiscoverButton = button [onClick address Discover] [i [class "fa fa-compass fa-2x"] []]
+        goMapButton = button [onClick address ViewMapScreen] [i [class "fa fa-map fa-2x"] []]
         goFavsButton = button [onClick address ViewFavourites] [i [class "fa fa-heart fa-2x"] []]
         logoDiv = div [class "logo"] [a [href "/"] [img [src "images/logo.png"] []]]
         navTitle title = h1 [] [text title]
@@ -44,9 +45,19 @@ navigation address location =
             Discovering -> navBarHtml
                 { side1 = []
                 , center = [logoDiv]
-                , side2 = [goFavsButton]
+                , side2 =
+                    [ goMapButton
+                    , goFavsButton ]
                 }
 
+            MapScreen -> navBarHtml
+                { side1 = []
+                , center = [logoDiv]
+                , side2 =
+                    [ goDiscoverButton
+                    , goFavsButton
+                    ]
+                }
 
 type alias NavBarElements =
     { side1 : List Html

--- a/prototype/src/Route.elm
+++ b/prototype/src/Route.elm
@@ -14,6 +14,7 @@ action url = case url of
     "discover"::_ -> [Discover]
     "favourites"::_ -> [ViewFavourites]
     "about"::_ -> [ViewAboutScreen]
+    "map"::_ -> [ViewMapScreen]
     "story"::storyId::storyScreen::_ ->
         let
             id = parseStoryId storyId
@@ -34,6 +35,7 @@ url old new = if old.location /= new.location then
         Just <| case new.location of
             SplashPage        -> RouteHash.set [""]
             AboutScreen       -> RouteHash.set ["about"]
+            MapScreen         -> RouteHash.set ["map"]
             Discovering       -> RouteHash.set ["discover"]
             ViewingFavourites -> RouteHash.set ["favourites"]
             Viewing storyId _ storyScreen -> RouteHash.set ["story", storyIdToStr storyId, urliseStoryScreen storyScreen]

--- a/prototype/src/Types.elm
+++ b/prototype/src/Types.elm
@@ -27,6 +27,7 @@ App screens:
 type Location id =
       SplashPage
     | AboutScreen
+    | MapScreen
     | Discovering
     | Viewing id ItemView StoryScreen
     | ViewingFavourites
@@ -56,6 +57,7 @@ type Action id a =
     | ViewFavourites
     | ViewSplashPage
     | ViewAboutScreen
+    | ViewMapScreen
     | Back
     | LoadData UpdaterFunction
     | LoadDiscoveryData (RemoteData (List id)) UpdaterFunction

--- a/prototype/src/View.elm
+++ b/prototype/src/View.elm
@@ -40,6 +40,9 @@ screenView address app = case app.location of
 
     SplashPage -> Splash.view
 
+    MapScreen -> div [class "map-screen"]
+        [ navigation address app.location ]
+
     AboutScreen -> div [class "about-screen"]
         [ navigation address app.location
         , About.view

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -200,6 +200,46 @@ html, body, body > div {
             width: 150px;
         }
 
+/* map style */
+.mapboxgl-marker.site-marker {
+    background-size: cover;
+    border-radius: 20px;
+    width: 40px;
+    height: 40px;
+    border-width: 0;
+}
+    .mapboxgl-marker.site-marker:hover {
+        box-shadow: 1px 1px 1px black;
+    }
+
+    .mapboxgl-popup-content {
+        max-width: 80%;
+    }
+    .popup-site-overview {
+        display: flex;
+        height: 100px;
+    }
+        .popup-site-text {
+            flex: 4 0;
+            margin-right: 5px;
+        }
+            .popup-site-text h1 {
+                color: black;
+                font-size: 14px;
+                margin: 0;
+                text-align: left;
+                font-weight: bold;
+            }
+        .popup-site-image {
+            flex: 0 1;
+            height: 100%;
+        }
+        .popup-site-image img {
+            height: 100%;
+        }
+
+
+
 
 /* About screen style */
 .about-screen {

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -28,6 +28,7 @@ html, body, body > div {
     height: 100%;
 }
 .map-container {
+    z-index: -1;
     height: 100%;
     width: 100%;
     padding-top: 65px;
@@ -36,15 +37,8 @@ html, body, body > div {
     box-sizing: border-box;
 }
 #map {
-    /*opacity: 0;*/
-    /*display: none;*/
-    z-index: -1;
-
-    /*padding-top: 65px;*/
     width: 100%;
     height: 100%;
-
-
 }
 
 /* Top of the page navigation */

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -27,6 +27,25 @@ html, body, body > div {
     flex-direction: column;
     height: 100%;
 }
+.map-container {
+    height: 100%;
+    width: 100%;
+    padding-top: 65px;
+    position: absolute;
+    top: 0;
+    box-sizing: border-box;
+}
+#map {
+    /*opacity: 0;*/
+    /*display: none;*/
+    z-index: -1;
+
+    /*padding-top: 65px;*/
+    width: 100%;
+    height: 100%;
+
+
+}
 
 /* Top of the page navigation */
 .navigation {

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -36,12 +36,19 @@ html, body, body > div {
      width: 100%;
      z-index: 2;
      display: flex;
+     justify-content: space-between;
+     box-sizing: border-box;
+     padding: 0 1em;
 }
 .navigation > div {
     flex: 1 0; /* grow, don't shrink */
 }
 .navigation button {
     height: 100%;
+}
+.navigation-side2 {
+    display: flex;
+    justify-content: flex-end;
 }
 
 /* adjust some screens to start after nav bar

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -35,6 +35,13 @@ html, body, body > div {
      position: fixed;
      width: 100%;
      z-index: 2;
+     display: flex;
+}
+.navigation > div {
+    flex: 1 0; /* grow, don't shrink */
+}
+.navigation button {
+    height: 100%;
 }
 
 /* adjust some screens to start after nav bar
@@ -78,7 +85,7 @@ html, body, body > div {
             color: white;
             background: none;
             border: none;
-            height: inherit;
+            /* height: inherit; */
             cursor: pointer;
             transition: all 0.3s ease 0s;
             opacity: 1;
@@ -93,8 +100,8 @@ html, body, body > div {
         }
 
         .navigation button:first-child {
-            position: absolute;
-            float: left;
+            /* position: absolute; */
+            /* float: left; */
             margin-left: 10px;
         }
 

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -48,7 +48,7 @@ html, body, body > div {
 }
 .navigation-side2 {
     display: flex;
-    justify-content: flex-end;
+    justify-content: space-around;
 }
 
 /* adjust some screens to start after nav bar
@@ -109,7 +109,7 @@ html, body, body > div {
         .navigation button:first-child {
             /* position: absolute; */
             /* float: left; */
-            margin-left: 10px;
+            /* margin: 0 10px; */
         }
 
         .navigation .logo {


### PR DESCRIPTION
Fixes #12 

This really needs a proper review (test on your own machine before merging). In fact, it's probably not really ready for merge yet (see notes below, but it is ready for some testing, and could be merged if we want to make incremental changes later - i.e. Jesse if you want to do styling feel free to merge to master then work from there). 

The API changed to make this work. From the top level folder, run this before testing:

```
cd backend
psql hnm -f hnm-views+functions.sql
```

Also, from the top level folder, make sure to rebuild the app:
```
cd prototype
make app
```

Things to note:
* This updates the nav layout to be closer to invision prototype (favs menu on right)
* for now I've been lazy and just making map accessible through top nav bar rather than another menu screen or the page flip effect 
* currently this just centers on Sydney -- we need to add code to watch for the browser's location and center there
* This doesn't yet handle sites with multiple stories.
* There is only basic styling on the info window popup for markers -- doesn't yet match invision.