### PR TITLE
update geocoder to use lat/long where available

### DIFF
--- a/etl/test/testGeocoder.js
+++ b/etl/test/testGeocoder.js
@@ -30,5 +30,51 @@ describe("geocoder.js", function () {
                 testDone()
             })
         })
+
+        it("skips geocoding when lat/lng already present", function (testDone) {
+            let items = [{
+                address: "foo bar",
+                location: { latitude: 0, longitude: 0 }
+            }]
+
+            // console.log("items:")
+            // console.log(items)
+
+            geocoder.geocode (items, function validator (err, locations) {
+                if (err) {
+                    console.log("geocoder error: ")
+                    console.log(err)
+                }
+
+                expect(items[0])
+                    .to.have.property("location")
+                    .that.is.an("object")
+                    .that.deep.equals({latitude: 0, longitude: 0})
+
+                testDone()
+            })
+        })
+
+        it("skips geocoding when no address given", function (testDone) {
+
+            let items = [{
+                address: "", // should be skipped if .address missing or empty
+                // note: no coordinates given, but no address, so geocoding should skip w/ warning
+            }]
+
+            geocoder.geocode (items, function validator (err, locations) {
+                if (err) {
+                    console.log("geocoder error: ")
+                    console.log(err)
+                }
+
+                expect(items[0])
+                    .to.not.have.property("location")
+
+                testDone()
+            })
+
+
+        })
     })
 })

--- a/etl/transform.js
+++ b/etl/transform.js
@@ -94,7 +94,8 @@ function cleanupHeritageRow (row) {
         suburb: row["Location/Suburb"],
         address: row["Street Address"],
         location: {},
-        // latitude / longitude: geocode location
+        latitude: row["Latitude"], // and we'll geocode address if these aren't present
+        longitude: row["Longitude"],
         heritage_categories: row["Heritage Categories"],
         architectural_style: row["Architectural Style"],
         links: parseLinks(row["Links & Further Reading"]),


### PR DESCRIPTION
* Fixes #113
* We now have lat/long in the input -- we should pull from that where possible and skip geocoding addresses in that case.
* If we ever have no address *and* no lat/long, we should just skip that row and provide a warning regarding that (like "Warning: No location for entry [title], not adding to database")