### PR TITLE
add search page

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -354,8 +354,8 @@
                     var resultsHtml = data.map(function (item) {
                         return '' +
                             '<div class="search-result">' +
-                                '<a class="cf" href="/#!/story/' + item.id + '/"><div class="search-result-title">' +
-                                    item.title +
+                                '<a class="cf" href="/#!/story/' + item.story_id + '/"><div class="search-result-title">' +
+                                    item.story_title +
                                 '</div>' +
                                 '<div class="search-result-photo"><img src="' + item.photo_url +'"></div>' +
                                 '<div class="clearfix"></div>' +

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -27,6 +27,13 @@
         <div class="map-container">
             <div id="map"></div>
         </div>
+        <div class="search-container">
+            <div id="search">
+                <div class="search-input-container">
+                    <input id="heritage-search" class="search-input" type="search">
+                </div>
+            </div>
+        </div>
 
 
         <script type="text/javascript">
@@ -314,7 +321,13 @@
             getSites();
 
 
+            /* JS for search functionality */
+            var e = document.getElementById('heritage-search');
 
+            e.oninput = function (e) {
+                console.log("searching for '" + e.target.value + "'");
+                // todo: run search and spit back results
+            }
 
             /* show map when Elm wants us to */
             mapContainerEl = document.getElementsByClassName("map-container")[0];
@@ -324,6 +337,17 @@
                     mapContainerEl.style.zIndex = '1';
                 } else {
                     mapContainerEl.style.zIndex = '-1';
+                }
+            });
+
+            /* show search when Elm wants us to */
+            searchContainerEl = document.getElementsByClassName("search-container")[0];
+            app.ports.showSearch.subscribe(function(show) {
+                console.log("show search: " + show);
+                if (show) {
+                    searchContainerEl.style.zIndex = '1';
+                } else {
+                    searchContainerEl.style.zIndex = '-1';
                 }
             });
 

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -32,6 +32,7 @@
                 <div class="search-input-container">
                     <input id="heritage-search" class="search-input" type="search">
                 </div>
+                <div id="search-results-container"></div>
             </div>
         </div>
 
@@ -322,11 +323,62 @@
 
 
             /* JS for search functionality */
+            var resultsDiv = document.getElementById("search-results-container");
+
             var e = document.getElementById('heritage-search');
 
             e.oninput = function (e) {
-                console.log("searching for '" + e.target.value + "'");
+                var q = e.target.value;
+
+                if (q.length < 3) {
+                    console.log("skipping too-short query string: " + q);
+                    resultsDiv.innerHTML = '';
+                    return;
+                }
+
+                console.log("searching for '" + q + "'");
                 // todo: run search and spit back results
+
+                var request = new XMLHttpRequest();
+                request.open("POST", "/api/rpc/search_stories", true);
+
+                request.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
+
+                request.onload = function(e) {
+                  if (request.status >= 200 && request.status < 400) {
+                    // Success!
+                    var data = JSON.parse(request.responseText);
+                    console.log("response:")
+                    console.log(data)
+
+                    var resultsHtml = data.map(function (item) {
+                        return '' +
+                            '<div class="search-result">' +
+                                '<a class="cf" href="/#!/story/' + item.id + '/"><div class="search-result-title">' +
+                                    item.title +
+                                '</div>' +
+                                '<div class="search-result-photo"><img src="' + item.photo_url +'"></div>' +
+                                '<div class="clearfix"></div>' +
+                                '</a>' +
+                            '</div>';
+                    }).join('');
+
+                    resultsDiv.innerHTML = resultsHtml;
+
+                  } else {
+                    // We reached our target server, but it returned an error
+                    console.log("server returned error")
+                  }
+                };
+
+                request.onerror = function() {
+                  // There was a connection error of some sort
+                  console.log("error connecting to server")
+                };
+
+                var data = JSON.stringify({query: e.target.value})
+                request.send(data);
+
             }
 
             /* show map when Elm wants us to */

--- a/prototype/src/App.elm
+++ b/prototype/src/App.elm
@@ -128,6 +128,9 @@ port showMap =
     in
         Signal.dropRepeats booleanSignal
 
+-- signal to js component when we need search screen displayed
+port showSearch : Signal Bool
+port showSearch = Signal.dropRepeats <| Signal.map (\m -> m.location == SearchScreen) app.model
 
 {-| Any time the model changes, Json-encode our fetched stories and send to JavaScript-land for mapping. -}
 --port mapMarkers : Signal Json.Encode.Value
@@ -231,6 +234,7 @@ updateModel action app = case (app.location, action) of
     (_, ViewFavourites)                       -> {app | location = ViewingFavourites}
     (_, ViewAboutScreen)                      -> {app | location = AboutScreen}
     (_, ViewMapScreen)                        -> {app | location = MapScreen}
+    (_, ViewSearchScreen)                     -> {app | location = SearchScreen}
     -- Data update actions
     (_, LoadData updateItems)                 -> {app | items = updateItems app.items}
     (_, LoadDiscoveryData items updateItems)  -> {app | items = updateItems app.items, discovery = updateDiscoverableItems app.discovery items}

--- a/prototype/src/Navigation.elm
+++ b/prototype/src/Navigation.elm
@@ -15,6 +15,7 @@ navigation address location =
         goDiscoverButton = button [onClick address Discover] [i [class "fa fa-compass fa-2x"] []]
         goMapButton = button [onClick address ViewMapScreen] [i [class "fa fa-map fa-2x"] []]
         goFavsButton = button [onClick address ViewFavourites] [i [class "fa fa-heart fa-2x"] []]
+        goSearchButton = button [onClick address ViewSearchScreen] [i [class "fa fa-search fa-2x"] []]
         logoDiv = div [class "logo"] [a [href "/"] [img [src "images/logo.png"] []]]
         navTitle title = h1 [] [text title]
         noNavBar = text ""
@@ -47,6 +48,7 @@ navigation address location =
                 , center = [logoDiv]
                 , side2 =
                     [ goMapButton
+                    , goSearchButton
                     , goFavsButton ]
                 }
 
@@ -55,6 +57,17 @@ navigation address location =
                 , center = [logoDiv]
                 , side2 =
                     [ goDiscoverButton
+                    , goSearchButton
+                    , goFavsButton
+                    ]
+                }
+
+            SearchScreen -> navBarHtml
+                { side1 = []
+                , center = [logoDiv]
+                , side2 =
+                    [ goDiscoverButton
+                    , goSearchButton
                     , goFavsButton
                     ]
                 }

--- a/prototype/src/Route.elm
+++ b/prototype/src/Route.elm
@@ -15,6 +15,7 @@ action url = case url of
     "favourites"::_ -> [ViewFavourites]
     "about"::_ -> [ViewAboutScreen]
     "map"::_ -> [ViewMapScreen]
+    "search"::_ -> [ViewSearchScreen]
     "story"::storyId::storyScreen::_ ->
         let
             id = parseStoryId storyId
@@ -36,6 +37,7 @@ url old new = if old.location /= new.location then
             SplashPage        -> RouteHash.set [""]
             AboutScreen       -> RouteHash.set ["about"]
             MapScreen         -> RouteHash.set ["map"]
+            SearchScreen      -> RouteHash.set ["search"]
             Discovering       -> RouteHash.set ["discover"]
             ViewingFavourites -> RouteHash.set ["favourites"]
             Viewing storyId _ storyScreen -> RouteHash.set ["story", storyIdToStr storyId, urliseStoryScreen storyScreen]

--- a/prototype/src/Types.elm
+++ b/prototype/src/Types.elm
@@ -28,6 +28,7 @@ type Location id =
       SplashPage
     | AboutScreen
     | MapScreen
+    | SearchScreen
     | Discovering
     | Viewing id ItemView StoryScreen
     | ViewingFavourites
@@ -58,6 +59,7 @@ type Action id a =
     | ViewSplashPage
     | ViewAboutScreen
     | ViewMapScreen
+    | ViewSearchScreen
     | Back
     | LoadData UpdaterFunction
     | LoadDiscoveryData (RemoteData (List id)) UpdaterFunction

--- a/prototype/src/View.elm
+++ b/prototype/src/View.elm
@@ -43,6 +43,9 @@ screenView address app = case app.location of
     MapScreen -> div [class "map-screen"]
         [ navigation address app.location ]
 
+    SearchScreen -> div [class "search-screen"]
+        [ navigation address app.location ]
+
     AboutScreen -> div [class "about-screen"]
         [ navigation address app.location
         , About.view

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -75,9 +75,11 @@ html, body, body > div {
 .story-screen.story-body .fullStory-meta,
 .story-screen.story-more-info .content-area,
 .discovery-screen .discovery-empty,
-.mapboxgl-ctrl-top-left,
-#search {
+.mapboxgl-ctrl-top-left {
     margin-top: 65px;
+}
+.search-container {
+    padding-top: 65px;
 }
 
 /*.story-screen .navigation, 

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -27,7 +27,7 @@ html, body, body > div {
     flex-direction: column;
     height: 100%;
 }
-.map-container {
+.map-container, .search-container {
     z-index: -1;
     height: 100%;
     width: 100%;
@@ -35,7 +35,7 @@ html, body, body > div {
     top: 0;
     box-sizing: border-box;
 }
-#map {
+#map, #search {
     width: 100%;
     height: 100%;
 }
@@ -75,7 +75,8 @@ html, body, body > div {
 .story-screen.story-body .fullStory-meta,
 .story-screen.story-more-info .content-area,
 .discovery-screen .discovery-empty,
-.mapboxgl-ctrl-top-left  {
+.mapboxgl-ctrl-top-left,
+#search {
     margin-top: 65px;
 }
 
@@ -359,6 +360,21 @@ html, body, body > div {
       }
     }
 
+/* Search screen style */
+
+.search-input-container {
+    background: #f7f5f3;
+    padding: 5px 10px;
+}
+    input.search-input {
+        background: #dad8d3;
+        width: 100%;
+        font-size: 16px;
+        border-radius: 5px;
+        border: none;
+        padding: 8px;
+        font-family: "proxima-nova";
+    }
 
 /* About screen style */
 .about-screen {

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -376,6 +376,37 @@ html, body, body > div {
         font-family: "proxima-nova";
     }
 
+    #search-results-container {
+    background: #ECE9E8;
+    padding: 5px 10px 5px 18px;
+    }
+
+    .search-result {
+        /*height: 40px;*/
+        padding: 5px 0;
+        border-bottom: 1px solid #e0e0e0;
+    }
+    .search-result:last-child {
+        border: none;
+    }
+    .search-result a {
+        text-decoration: none;
+        color: black;
+        display: block;
+    }
+    .search-result-title {
+        padding-top: 5px;
+        max-width: 80%; /* keep title + image on same line */
+        float: left;
+    }
+    .search-result-photo {
+        height: 30px;
+        float: right;
+    }
+    .search-result-photo img {
+        height: 100%;
+    }
+
 /* About screen style */
 .about-screen {
     background: #383636;
@@ -1087,4 +1118,32 @@ button {
 /* Other tweaks */
 .app .fa-inverse {
     color: #1D1D1D;
+}
+
+
+/** clearfix used by bootstrap - http://nicolasgallagher.com/micro-clearfix-hack/
+ * For modern browsers
+ * 1. The space content is one way to avoid an Opera bug when the
+ *    contenteditable attribute is included anywhere else in the document.
+ *    Otherwise it causes space to appear at the top and bottom of elements
+ *    that are clearfixed.
+ * 2. The use of `table` rather than `block` is only necessary if using
+ *    `:before` to contain the top-margins of child elements.
+ */
+.cf:before,
+.cf:after {
+    content: " "; /* 1 */
+    display: table; /* 2 */
+}
+
+.cf:after {
+    clear: both;
+}
+
+/**
+ * For IE 6/7 only
+ * Include this rule to trigger hasLayout and contain floats.
+ */
+.cf {
+    *zoom: 1;
 }


### PR DESCRIPTION
Fixes #99 

See #99 or commits here for changes made, but basically:

* New API endpoint (`POST /api/rpc/search_stories BODY = { query: "some string" }`) for performing search across story titles and suburb names.
* Elm keeps track of state, updates URL hash and signals through a port to JS when the search screen should be shown
* JS fires a request to the API when the search input field is updated

Todo later:
* cache results so we don't fire same request redundantly
* maybe have a source for smaller images to include in search results
* maybe highlight what matched
* maybe search suburbs too