### PR TITLE
on story view, show photo even if we only have one

### DIFF
--- a/prototype/src/Story.elm
+++ b/prototype/src/Story.elm
@@ -138,19 +138,24 @@ introOrBody story storyScreen =
 
 photoSlider : Signal.Address AppAction -> Story -> ItemView -> StoryScreen -> Html
 photoSlider address story item screen =
-    if screen == Intro && (List.length <| photos story) > 1 then
-        div
-            ([class "photo-slide"] ++ onSwipe address (itemSwipe item.photoPosition) swipePhotoAction)
-            [ div [class "photos"]
-                <| List.map (storyImage story item.photoPosition) [item.photoIndex-1, item.photoIndex, item.photoIndex+1]
-            , photoIndicators address story item.photoIndex
-            ]
-    else if screen == Body then
-        div
-            [class "photos"]
-            [storyImage story item.photoPosition item.photoIndex]
-    else
-        text ""
+    let
+        numStories = List.length <| photos story
+    in
+        if screen == Intro && numStories > 1 then
+            div
+                ([class "photo-slide"] ++ onSwipe address (itemSwipe item.photoPosition) swipePhotoAction)
+                [ div [class "photos"]
+                    <| List.map (storyImage story item.photoPosition) [item.photoIndex-1, item.photoIndex, item.photoIndex+1]
+                , photoIndicators address story item.photoIndex
+                ]
+
+        else if screen == Body || (screen == Intro && numStories == 1) then
+            div
+                [class "photos"]
+                [storyImage story item.photoPosition item.photoIndex]
+
+        else
+            text ""
 
 log : a -> a
 log anything =


### PR DESCRIPTION
* previously, if we only had one photo the app wouldn't show it on the story into screen (see #123).
* This commit catches that case (Intro screen w/ just one photo) and outputs the html to show that photo

* fixes #123

(Note, it looks like a bunch of lines changed because when I switched to using the `let...in` syntax it means the stuff in the `in` part of the clause gets indented a tab. I also added a little whitespace. But if you look closely, not that much has changed, just mainly:

```
else if screen == Body then
```
becomes:
```
else if screen == Body || (screen == Intro && numStories == 1) then
```