### PR TITLE
Changed the order of the Makefile

### DIFF
--- a/prototype/Makefile
+++ b/prototype/Makefile
@@ -1,4 +1,6 @@
-
+app:
+	elm make src/App.elm --output swipe-local-history.js
+	
 docs:
 	elm make --docs=documentation.json
 	@echo now upload documentation.json to http://package.elm-lang.org/help/docs-preview
@@ -11,7 +13,3 @@ osxClear:
 
 clean:
 	rm -rf elm-stuff/build-artifacts/0.16.0/user/project/
-
-app:
-	elm make src/App.elm --output swipe-local-history.js
-


### PR DESCRIPTION
* moved 'app:' to the top of the Makefile
  so now you can just type make to run what was previously
  'make app'