### PR TITLE
improve logging

### DIFF
--- a/prototype/src/App.elm
+++ b/prototype/src/App.elm
@@ -43,6 +43,7 @@ import Data
 import View exposing (view)
 import Story
 import Swiping
+import Console
 
 
 {-| The initial state /model of the app
@@ -203,8 +204,8 @@ and viewing the console while starting the app.
 update: AppAction -> AppModel -> (AppModel, Effects.Effects AppAction)
 update action model =
     let
-        _ = Debug.log "update w/ model.location" model.location
-        _ = Debug.log "update w/ action" action
+        _ = Console.log "update w/ model.location" model.location
+        _ = Console.log "update w/ action" action
     in
         (updateModel action model, updateAction action model)
 
@@ -243,8 +244,8 @@ updateModel action app = case (app.location, action) of
     -- Do nothing for the rest of the actions
     (_, _)                                    ->
         let
-            _ = Debug.log "updateModel, no change for location" app.location
-            _ = Debug.log "updateModel, no change for action  " action
+            _ = Console.log "updateModel, no change for location" app.location
+            _ = Console.log "updateModel, no change for action  " action
         in
             app
 

--- a/prototype/src/Console.elm
+++ b/prototype/src/Console.elm
@@ -1,0 +1,22 @@
+module Console (log) where
+
+
+{-| The Console module provides console debug logging.
+
+Under the hood, it just calls Debug.log, but lets us quickly disable that.
+
+# Console logging
+
+@docs log
+
+-}
+
+log : String -> a -> a
+log msg a =
+    let
+        enabled = False -- set to False to disable logging
+    in
+        if enabled then
+            Debug.log msg a
+        else
+            a

--- a/prototype/src/View.elm
+++ b/prototype/src/View.elm
@@ -19,6 +19,7 @@ import Navigation exposing (navigation)
 import Discover
 import Story
 import Favourites
+import Console
 
 
 {-| The main view for the app.
@@ -28,7 +29,7 @@ It also passes the address for UI actions (such as clicking and swiping) to the 
 view : Signal.Address AppAction -> AppModel -> Html
 view address app =
     let
-        _ = Debug.log "Viewing location" app.location
+        _ = Console.log "Viewing location" app.location
         content = screenView address app
     in
         div [class "app screen-size"] [content]


### PR DESCRIPTION
* Debug.log is still used in some modules but this vastly reduces console log
  volume by turning it off on state changes (which switches quite a lot
  thanks to the Animation code).

* If you want to use the new Console.log function, just `import Console` near the top of the file and then replace `Debug.log` with `Console.log`. 

* Note that this just has a simple global on/off for logging through Console.log. We could add categories later if really necessary (and remember you've also got [this trick](stackoverflow.com/questions/38823920/is-it-possible-to-filter-chrome-console-log-using-a-negated-text) for filtering out those Animation lines if you need to see state changes). 