### PR TITLE
prevent map popup site image from overflowing out of popup

### DIFF
--- a/prototype/style.css
+++ b/prototype/style.css
@@ -252,7 +252,7 @@ html, body, body > div {
         height: 50px;
     }
         .popup-site-text {
-            flex: 4 0;
+            flex: 1 0;
             margin: 10px;
         }
             .popup-site-text h1 {
@@ -276,7 +276,7 @@ html, body, body > div {
         }
 
         .popup-site-image {
-            flex: 2 0;
+            flex: 1 0;
             height: 100%;
             max-width: 70px;
         }


### PR DESCRIPTION
* fixes #148
* we set the flexbox grow factor to 1 on both site name and site image so Safari
  doesn't think it's necessary to give the site name so much room it pushes the image slightly
  out of the popup area
* note that the max-width on the image prevents it from being larger than 70 pix wide anyway,
  and the popup should always be 200px wide so the image will take up at most about 1/3 of the
  popup width, which is pretty ideal.

Tested in Chrome:

![image](https://cloud.githubusercontent.com/assets/1072292/18274280/0340d17c-7485-11e6-973f-56d36f4d5b51.png)


and Safari:

![image](https://cloud.githubusercontent.com/assets/1072292/18274285/0dd61d04-7485-11e6-9826-b1872eeee212.png)
