### PR TITLE
Fix server config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,15 @@ server-dbinit:
 server-dropdb:
 	su postgres -c "dropdb --if-exists $(DB)"
 
-RUN_API="postgrest postgres://localhost:5432/hnm --port 3000 --schema hnm --anonymous $(DB_USER) --pool 200"
+server-install-api-service:
+	sudo touch /var/log/heritage-api.log
+	sudo chown postgres /var/log/heritage-api.log
+	sudo mkdir -p /var/run/heritage
+	sudo chown postgres /var/run/heritage
+	sudo cp server/heritage-api.conf /etc/init
 
 server-apistart:
-	screen -S hnm-api -d -m $(RUN_API)
+	sudo service heritage-api start
 
 server-update-from-git:
 	git pull

--- a/server/heritage-api.conf
+++ b/server/heritage-api.conf
@@ -1,0 +1,41 @@
+# heritage-api - Start PostgREST API service for Heritage Near Me
+# This is an upstart config file for Linux; it goes in /etc/init
+# Read more:
+# * https://www.digitalocean.com/community/tutorials/the-upstart-event-system-what-it-is-and-how-to-use-it
+# * https://www.digitalocean.com/community/tutorials/how-to-configure-a-linux-service-to-start-automatically-after-a-crash-or-reboot-part-1-practical-examples
+
+#
+# Note: when installing this, run this as root before running the service:
+#
+# touch /var/log/heritage-api.log
+# chown postgres /var/log/heritage-api.log
+# mkdir -p /var/run/heritage
+# chown postgres /var/run/heritage
+
+
+description "Start Heritage Near Me API (PostgREST)"
+author "Peter W (@techieshark)"
+
+start on filesystem or runlevel [2345]
+stop on shutdown
+
+# Run as "postgres" user since that has correct access to database
+setuid postgres
+
+script
+
+    echo $$ > /var/run/heritage-api.pid
+    exec postgrest postgres://localhost:5432/hnm --port 3000 --schema hnm --anonymous postgres --pool 200 > /var/log/heritage-api.log
+
+end script
+
+
+pre-start script
+    echo "[`date`] Heritage API Starting" >> /var/log/heritage-api.log
+end script
+
+
+pre-stop script
+    rm /var/run/heritage-api.pid
+    echo "[`date`] Heritage API Stopping" >> /var/log/heritage-api.log
+end script


### PR DESCRIPTION
Running `make  server-apistart` didn't work well before. This should fix that. Needs a double check though (maybe delete /var/run/heritage, /var/log/heritage-api.log, and /etc/init/heritage-api and then run 

```
make server-install-api-service:
make  server-apistart
```
